### PR TITLE
Rectified syntax error

### DIFF
--- a/book-recommender-system.ipynb
+++ b/book-recommender-system.ipynb
@@ -525,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "db1b0fd4",
    "metadata": {},
    "outputs": [
@@ -638,7 +638,7 @@
     }
    ],
    "source": [
-    "avg_rating_df = ratings_with_name.groupby('Book-Title').mean()['Book-Rating'].reset_index()\n",
+    "avg_rating_df = ratings_with_name.groupby('Book-Title')['Book-Rating'].mean().reset_index()\n",
     "avg_rating_df.rename(columns={'Book-Rating':'avg_rating'},inplace=True)\n",
     "avg_rating_df"
    ]


### PR DESCRIPTION
The code to find the average was throwing an error since **mean operation** was being performed on the entire dataframe which includes **object datatypes** as well.  After modification, the code is currently performing mean operation after selecting the **Book-Rating** column alone.